### PR TITLE
Apparently some of the links to images we're using are pretty long to…

### DIFF
--- a/models/Recipe.js
+++ b/models/Recipe.js
@@ -27,7 +27,7 @@ Recipe.init(
         allowNull: false,
     },
     image: {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT('long'),
         allowNull: false,
     },
     ingredients: {


### PR DESCRIPTION
…o.  Changing the length of the Recipe.image field to account for longer values like that