### PR TITLE
Adding functionality to Meal History page, only displaying meals that…

### DIFF
--- a/controllers/api/mealRoutes.js
+++ b/controllers/api/mealRoutes.js
@@ -113,7 +113,8 @@ router.get('/meal_history', withAuth, async (req, res) => {
   try {
 
     const userHistory = await Recipe.findAll({
-      include: [{ model: User, through: UserToRecipe, as: 'meals_cooked', where: { id: req.session.user_id }  }],
+      // include: [{ model: User, through: UserToRecipe, as: 'meals_cooked', where: { id: req.session.user_id }  }],
+      include: [{ model: UserToRecipe, where: { user_id: req.session.user_id, cooked: true }  }],
     });
 
     const history = userHistory.map((cookedMeal) =>

--- a/models/index.js
+++ b/models/index.js
@@ -27,7 +27,7 @@ Recipe.hasOne(UserToRecipe, {
   foreignKey: 'recipe_id',
 });
 UserToRecipe.belongsTo(Recipe, {
-  foreignKey: 'recipe_id',
+  foreignKey: 'id',
 });
 
 module.exports = {


### PR DESCRIPTION
… actually have the user_to_recipe.cooked flag toggled in the DB.  If you are on the history page, and untoggle the checkbox and refresh the page, it will update in the database from here now as well